### PR TITLE
Centralize web routes and add navigation links to mobile app

### DIFF
--- a/apps/mobile/src/app/(app)/other/index.tsx
+++ b/apps/mobile/src/app/(app)/other/index.tsx
@@ -1,27 +1,48 @@
-import { Button } from '@/components/ui/button'
 import { Text } from '@/components/ui/text'
 import { useSession } from '@/lib/ctx'
+import { getWebUrl } from '@/lib/url'
+import { webRoutes, type WebRouteKey } from '@gridtip/shared/routes'
 import { Stack } from 'expo-router'
-import { View, StyleSheet } from 'react-native'
+import * as WebBrowser from 'expo-web-browser'
+import { Pressable, ScrollView, View } from 'react-native'
+
+type LinkItem = {
+  title: string
+  routeKey: WebRouteKey
+}
+
+const links: LinkItem[] = [
+  { title: 'Leaderboard', routeKey: 'leaderboard' },
+  { title: 'Championships', routeKey: 'championships' },
+  { title: 'Groups', routeKey: 'groups' },
+  { title: 'Rules & Scoring', routeKey: 'rules' },
+  { title: 'Settings', routeKey: 'settings' },
+  { title: 'Feedback', routeKey: 'feedback' },
+  { title: 'Privacy', routeKey: 'privacy' },
+]
 
 export default function Other() {
   const { signOut } = useSession()
+
+  function openLink(routeKey: WebRouteKey) {
+    WebBrowser.openBrowserAsync(getWebUrl(webRoutes[routeKey]))
+  }
+
   return (
     <>
       <Stack.Screen options={{ title: 'Other' }} />
-      <View style={styles.container}>
-        <Button onPress={signOut}>
-          <Text>Sign out</Text>
-        </Button>
-      </View>
+      <ScrollView>
+        <View>
+          {links.map((link) => (
+            <Pressable key={link.routeKey} onPress={() => openLink(link.routeKey)}>
+              <Text>{link.title}</Text>
+            </Pressable>
+          ))}
+          <Pressable onPress={signOut}>
+            <Text>Sign out</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
     </>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-})

--- a/apps/web/app/(public)/layout.tsx
+++ b/apps/web/app/(public)/layout.tsx
@@ -3,6 +3,7 @@ import { AppHeader } from '../../components/app-header'
 import { Button } from '@ui/button'
 import { Path } from '@/lib/utils/path'
 import { getMaybeSession } from '@/lib/dal'
+import { webRoutes } from '@gridtip/shared/routes'
 
 export default async function DefaultLayout({
   children,
@@ -56,7 +57,7 @@ function AppFooter() {
   return (
     <div className='border-t py-2 flex items-center justify-between text-sm is-container text-muted-foreground'>
       <Button asChild variant='link' className='text-muted-foreground'>
-        <Link href='/privacy' title='Privacy Policy'>
+        <Link href={webRoutes.privacy} title='Privacy Policy'>
           Privacy
         </Link>
       </Button>

--- a/apps/web/components/nav-main.tsx
+++ b/apps/web/components/nav-main.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/sidebar'
 import { Database } from '@/db/types'
 import { Icon } from './icon'
+import { webRoutes } from '@gridtip/shared/routes'
 
 export const nav = [
   {
@@ -36,7 +37,7 @@ export const nav = [
       },
       {
         title: 'Championships',
-        url: '/tipping/championships',
+        url: webRoutes.championships,
       },
     ],
   },
@@ -48,11 +49,11 @@ export const nav = [
     items: [
       {
         title: 'Leaderboard',
-        url: '/tipping/leaderboard',
+        url: webRoutes.leaderboard,
       },
       {
         title: 'Rules & Scoring',
-        url: '/tipping/rules',
+        url: webRoutes.rules,
       },
     ],
   },
@@ -64,15 +65,15 @@ export const nav = [
     items: [
       {
         title: 'Groups',
-        url: '/tipping/groups',
+        url: webRoutes.groups,
       },
       {
         title: 'Feedback',
-        url: '/tipping/contact',
+        url: webRoutes.feedback,
       },
       {
         title: 'Settings',
-        url: '/tipping/settings',
+        url: webRoutes.settings,
       },
     ],
   },

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "gridtip-mono",
@@ -65,6 +66,7 @@
       "name": "f1-tipping-react",
       "version": "0.1.0",
       "dependencies": {
+        "@gridtip/shared": "workspace:*",
         "@hookform/resolvers": "^5.2.1",
         "@libsql/client": "^0.15.14",
         "@paralleldrive/cuid2": "^2.2.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gridtip/shared",
   "exports": {
-    "./constants": "./src/constants.ts"
+    "./constants": "./src/constants.ts",
+    "./routes": "./src/routes.ts"
   }
 }

--- a/packages/shared/src/routes.ts
+++ b/packages/shared/src/routes.ts
@@ -1,0 +1,11 @@
+export const webRoutes = {
+  leaderboard: '/tipping/leaderboard',
+  championships: '/tipping/championships',
+  groups: '/tipping/groups',
+  rules: '/tipping/rules',
+  settings: '/tipping/settings',
+  feedback: '/tipping/contact',
+  privacy: '/privacy',
+} as const
+
+export type WebRouteKey = keyof typeof webRoutes


### PR DESCRIPTION
## Summary
This PR centralizes web route definitions into a shared package and uses them across both web and mobile applications. It also enhances the mobile "Other" screen with navigation links to key features.

## Key Changes
- **Created centralized route definitions** (`packages/shared/src/routes.ts`):
  - Defined `webRoutes` object with all application routes (leaderboard, championships, groups, rules, settings, feedback, privacy)
  - Exported `WebRouteKey` type for type-safe route references
  - Updated package exports to include the new routes module

- **Updated web navigation** (`apps/web/components/nav-main.tsx`):
  - Replaced hardcoded route strings with references to `webRoutes` object
  - Ensures consistency across navigation items

- **Updated web footer** (`apps/web/app/(public)/layout.tsx`):
  - Changed privacy link to use `webRoutes.privacy` instead of hardcoded path

- **Enhanced mobile "Other" screen** (`apps/mobile/src/app/(app)/other/index.tsx`):
  - Added list of navigation links (Leaderboard, Championships, Groups, Rules & Scoring, Settings, Feedback, Privacy)
  - Implemented `openLink()` function to open web routes in external browser using `expo-web-browser`
  - Replaced centered button layout with scrollable list of pressable items
  - Removed unused `Button` component and `StyleSheet`

## Implementation Details
- Mobile app uses `getWebUrl()` helper to construct full URLs from route paths before opening in browser
- Type-safe route handling through `WebRouteKey` type ensures consistency between mobile and web
- Shared routes package enables single source of truth for all navigation paths

https://claude.ai/code/session_015jetuw1ogm7pi78hQnHs4m