### PR TITLE
Handle unauthorized API responses and clear session on 401

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -9,6 +9,7 @@ import { NAV_THEME } from '@/lib/theme'
 import { QueryClient, focusManager } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { asyncStoragePersister } from '@/lib/persister'
+import { UnauthorizedError } from '@/lib/api'
 import { useEffect } from 'react'
 import type { AppStateStatus } from 'react-native'
 
@@ -16,7 +17,12 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       gcTime: 1000 * 60 * 60 * 24, // 24h
-      retry: 2,
+      retry: (failureCount, error) => {
+        if (error instanceof UnauthorizedError) {
+          return false
+        }
+        return failureCount < 2
+      },
     },
   },
 })

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -10,13 +10,26 @@ import {
 } from '@gridtip/shared/api-types'
 import { type Position } from '@gridtip/shared/get-form-fields'
 
+export class UnauthorizedError extends Error {
+  constructor(message = 'Unauthorized') {
+    super(message)
+    this.name = 'UnauthorizedError'
+  }
+}
+
+let onUnauthorized: (() => void) | null = null
+
+export function setOnUnauthorized(handler: (() => void) | null) {
+  onUnauthorized = handler
+}
+
 export async function api<TResult extends object>(
   path: string,
   session: MaybeSession,
   options?: Omit<RequestInit, 'headers'>,
 ) {
   if (!session) {
-    throw new Error('No session')
+    throw new UnauthorizedError('No session')
   }
   const apiBaseUrl = getWebUrl('/api/v1/')
   const url = new URL(path, apiBaseUrl)
@@ -26,6 +39,10 @@ export async function api<TResult extends object>(
     },
     ...options,
   })
+  if (response.status === 401) {
+    onUnauthorized?.()
+    throw new UnauthorizedError()
+  }
   const text = await response.text()
   if (!response.ok) {
     throw new Error(text)

--- a/apps/mobile/src/lib/ctx.tsx
+++ b/apps/mobile/src/lib/ctx.tsx
@@ -1,7 +1,10 @@
-import { use, createContext, type PropsWithChildren } from 'react'
+import { use, createContext, useEffect, type PropsWithChildren } from 'react'
+import { useRouter } from 'expo-router'
+import { useQueryClient } from '@tanstack/react-query'
 
 import { useStorageState } from '@/hooks/use-storage-state'
 import { MaybeSession } from '@/hooks/use-dal'
+import { setOnUnauthorized } from './api'
 
 const AuthContext = createContext<{
   signIn: (token: string) => void
@@ -26,6 +29,19 @@ export function useSession() {
 
 export function SessionProvider({ children }: PropsWithChildren) {
   const [[isLoading, token], setToken] = useStorageState('session')
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    setOnUnauthorized(() => {
+      setToken(null)
+      queryClient.clear()
+      router.replace('/auth/sign-in')
+    })
+    return () => {
+      setOnUnauthorized(null)
+    }
+  }, [router, queryClient, setToken])
 
   return (
     <AuthContext.Provider


### PR DESCRIPTION
## Summary
This PR adds proper handling for unauthorized (401) API responses by introducing an `UnauthorizedError` exception class and a callback mechanism to clear the user session and redirect to the sign-in page when authentication fails.

## Key Changes
- **New `UnauthorizedError` class**: Custom error type to distinguish authorization failures from other errors
- **Unauthorized callback handler**: Added `setOnUnauthorized()` function to register a callback that executes when a 401 response is received
- **API 401 response handling**: The `api()` function now detects 401 status codes, invokes the unauthorized callback, and throws `UnauthorizedError`
- **Session cleanup on auth failure**: `SessionProvider` registers a callback that clears the stored token, invalidates React Query cache, and redirects to the sign-in page
- **Smart retry logic**: Updated React Query's retry configuration to skip retries for `UnauthorizedError`, preventing unnecessary retry attempts on auth failures

## Implementation Details
- The unauthorized handler is set up in `SessionProvider` with proper cleanup on unmount to prevent memory leaks
- The callback mechanism allows the API layer to remain decoupled from navigation and session management concerns
- React Query will no longer retry failed requests that result in authorization errors, improving user experience by immediately redirecting to sign-in

https://claude.ai/code/session_01KnFCEfiYuHauABaQE6rrTn