### PR TITLE
update loading states on mobile home screen

### DIFF
--- a/apps/mobile/src/app/(app)/home/_components/home-screen.tsx
+++ b/apps/mobile/src/app/(app)/home/_components/home-screen.tsx
@@ -14,6 +14,7 @@ export default function HomeScreen({
   drivers,
   groups,
   session,
+  isTipsPending,
 }: {
   nextRace: Race
   apiTips: GetTipsResponse | undefined
@@ -21,6 +22,7 @@ export default function HomeScreen({
   drivers: Driver[]
   groups: Group[]
   session: Session
+  isTipsPending: boolean
 }) {
   const defaultValues = useMemo<TipFormDefaultValues>(() => {
     if (!apiTips) {
@@ -50,12 +52,14 @@ export default function HomeScreen({
     <View className="flex flex-col gap-8 pb-8">
       <Header race={nextRace} />
       <TipForm
+        key={isTipsPending ? 'pending' : 'loaded'}
         session={session}
         defaultValues={defaultValues}
         race={nextRace}
         constructors={constructors}
         drivers={drivers}
         groups={groups}
+        isPending={isTipsPending}
       />
     </View>
   )

--- a/apps/mobile/src/app/(app)/home/_components/tip-form.tsx
+++ b/apps/mobile/src/app/(app)/home/_components/tip-form.tsx
@@ -43,6 +43,7 @@ export default function TipForm({
   groups,
   defaultValues,
   session,
+  isPending,
 }: {
   race: Race
   constructors: Constructor[]
@@ -50,6 +51,7 @@ export default function TipForm({
   groups: Group[]
   defaultValues: TipFormDefaultValues
   session: Session
+  isPending: boolean
 }) {
   const formFields = getFormFields(getIsSprint(race))
   const [isPresented, setIsPresented] = useState(false)
@@ -123,13 +125,13 @@ export default function TipForm({
         {formFields.map((field) => (
           <View key={field.name} className="flex flex-col gap-2">
             <Label className="px-2">{field.label}</Label>
-            <Button onPress={() => openModal(field)} variant="outline">
+            <Button onPress={() => openModal(field)} variant="outline" disabled={isPending}>
               <FieldContent field={field} />
             </Button>
             <Text className="px-2 text-sm text-muted-foreground">{field.description}</Text>
           </View>
         ))}
-        <Button className="mt-4" onPress={onSubmit}>
+        <Button className="mt-4" onPress={onSubmit} disabled={isPending}>
           <Text>Submit</Text>
         </Button>
       </View>
@@ -179,6 +181,9 @@ export default function TipForm({
   }
 
   function FieldContent({ field }: { field: Position }) {
+    if (isPending) {
+      return <Text>Loading…</Text>
+    }
     const value = formState[field.name]?.value
     if (!value) {
       return <Text>Select {field.type}</Text>

--- a/apps/mobile/src/app/(app)/home/index.tsx
+++ b/apps/mobile/src/app/(app)/home/index.tsx
@@ -101,25 +101,12 @@ function AuthentificatedHomeScreen({ session }: { session: Session }) {
     }),
   )
 
-  // Pending
-  const isAnyPending = useMemo(() => {
-    return [
-      lastUpdatedQuery.isPending,
-      racesQuery.isPending,
-      driversQuery.isPending,
-      constructorsQuery.isPending,
-      groupsQuery.isPending,
-      myTips.isFetching,
-    ].some(Boolean)
-  }, [
-    lastUpdatedQuery.isPending,
-    racesQuery.isPending,
-    driversQuery.isPending,
-    constructorsQuery.isPending,
-    groupsQuery.isPending,
-    myTips.isFetching,
-  ])
-  if (isAnyPending) return <LoadingState />
+  // Loading
+  if (lastUpdatedQuery.isPending) return <LoadingState message="Loading updates" />
+  if (racesQuery.isPending) return <LoadingState message="Loading races" />
+  if (driversQuery.isPending) return <LoadingState message="Loading drivers" />
+  if (constructorsQuery.isPending) return <LoadingState message="Loading constructors" />
+  if (groupsQuery.isPending) return <LoadingState message="Loading groups" />
 
   // Errors
   if (lastUpdatedQuery.isError) return <ErrorState message={lastUpdatedQuery.error.message} />
@@ -140,16 +127,17 @@ function AuthentificatedHomeScreen({ session }: { session: Session }) {
       constructors={constructorsQuery.data.constructors}
       groups={groupsQuery.data.groups}
       apiTips={myTips.data || undefined}
+      isTipsPending={myTips.isFetching}
     />
   )
 }
 
-function LoadingState() {
+function LoadingState({ message }: { message?: string }) {
   return (
     <View className="mx-4 py-16">
       <View className="flex items-center justify-center gap-2 flex-row">
         <Spinner />
-        <Text className="text-muted-foreground">Loading…</Text>
+        <Text className="text-muted-foreground">{message ? `${message}…` : 'Loading…'}</Text>
       </View>
     </View>
   )


### PR DESCRIPTION
show distinct messages per query while loading, and decouple the tips
fetch from the page-level loading gate so the form renders immediately
with disabled fields and "Loading…" placeholders until tips arrive.