### PR TITLE
add sidebar variations showcase page

### DIFF
--- a/apps/web/app/sidebar-variations/_components/mock-data.ts
+++ b/apps/web/app/sidebar-variations/_components/mock-data.ts
@@ -1,0 +1,74 @@
+import {
+  BarChart3,
+  BookOpen,
+  LayoutDashboard,
+  ListOrdered,
+  MessageSquare,
+  PencilLine,
+  Settings,
+  Settings2,
+  Trophy,
+  Users,
+  type LucideIcon,
+} from 'lucide-react'
+import { Icon } from '@/components/icon'
+
+export type NavItem = {
+  title: string
+  href: string
+  icon: LucideIcon
+  shortcut?: string
+  active?: boolean
+}
+
+export type NavSection = {
+  title: string
+  icon: LucideIcon
+  items: NavItem[]
+}
+
+export const navSections: NavSection[] = [
+  {
+    title: 'Tipping',
+    icon: Icon.Tipping,
+    items: [
+      {
+        title: 'Dashboard',
+        href: '#',
+        icon: LayoutDashboard,
+        shortcut: 'G D',
+        active: true,
+      },
+      { title: 'Enter tips', href: '#', icon: PencilLine, shortcut: 'G T' },
+      { title: 'Championships', href: '#', icon: Trophy, shortcut: 'G C' },
+    ],
+  },
+  {
+    title: 'Results',
+    icon: ListOrdered,
+    items: [
+      { title: 'Leaderboard', href: '#', icon: BarChart3, shortcut: 'G L' },
+      { title: 'Rules & Scoring', href: '#', icon: BookOpen, shortcut: 'G R' },
+    ],
+  },
+  {
+    title: 'Manage',
+    icon: Settings2,
+    items: [
+      { title: 'Groups', href: '#', icon: Users, shortcut: 'G G' },
+      { title: 'Feedback', href: '#', icon: MessageSquare, shortcut: 'G F' },
+      { title: 'Settings', href: '#', icon: Settings, shortcut: 'G S' },
+    ],
+  },
+]
+
+export const mockGroup = {
+  name: 'Box Box Tippers',
+  initials: 'BB',
+}
+
+export const mockUser = {
+  name: 'Lewis Hamilton',
+  email: 'lewis@gridtip.app',
+  initials: 'LH',
+}

--- a/apps/web/app/sidebar-variations/_components/variation-linear.tsx
+++ b/apps/web/app/sidebar-variations/_components/variation-linear.tsx
@@ -1,0 +1,81 @@
+import { ChevronDown, Search } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { mockGroup, mockUser, navSections } from './mock-data'
+
+export function VariationLinear() {
+  return (
+    <aside className='flex h-full w-64 flex-col bg-sidebar text-sidebar-foreground text-[13px]'>
+      <div className='flex items-center gap-2 px-3 pt-3 pb-2'>
+        <div className='flex size-5 items-center justify-center rounded bg-foreground/90 text-[10px] font-bold text-background'>
+          {mockGroup.initials.charAt(0)}
+        </div>
+        <div className='flex-1 truncate font-medium'>{mockGroup.name}</div>
+        <ChevronDown className='size-3.5 text-muted-foreground' />
+      </div>
+
+      <div className='px-3 pb-2'>
+        <div className='flex items-center gap-2 rounded-md border border-sidebar-border bg-foreground/[0.02] px-2 py-1.5 text-muted-foreground'>
+          <Search className='size-3.5' />
+          <span className='flex-1 text-[12px]'>Search…</span>
+          <kbd className='rounded border border-sidebar-border bg-background px-1 py-px font-mono text-[10px] leading-none'>
+            ⌘K
+          </kbd>
+        </div>
+      </div>
+
+      <nav className='flex-1 overflow-y-auto px-1.5 py-1'>
+        {navSections.map((section, index) => (
+          <div key={section.title} className={cn(index > 0 && 'mt-3')}>
+            <div className='relative flex items-center px-2 pb-1.5 pt-1'>
+              <span className='text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80'>
+                {section.title}
+              </span>
+            </div>
+            <ul className='flex flex-col'>
+              {section.items.map((item) => (
+                <li key={item.title} className='relative'>
+                  {item.active && (
+                    <span className='absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-r bg-foreground' />
+                  )}
+                  <a
+                    href={item.href}
+                    className={cn(
+                      'group flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors',
+                      'hover:bg-foreground/[0.04]',
+                      item.active && 'bg-foreground/[0.05] font-medium',
+                    )}
+                  >
+                    <item.icon className='size-3.5 shrink-0 text-muted-foreground' />
+                    <span className='flex-1 truncate'>{item.title}</span>
+                    {item.shortcut && (
+                      <span className='font-mono text-[10px] text-muted-foreground/50 opacity-0 transition-opacity group-hover:opacity-100'>
+                        {item.shortcut}
+                      </span>
+                    )}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </nav>
+
+      <div className='border-t border-sidebar-border px-3 py-2'>
+        <div className='flex items-center gap-2'>
+          <div className='relative'>
+            <div className='flex size-6 items-center justify-center rounded-full bg-foreground/10 text-[10px] font-medium'>
+              {mockUser.initials}
+            </div>
+            <span className='absolute -bottom-0.5 -right-0.5 size-2 rounded-full bg-emerald-500 ring-2 ring-sidebar' />
+          </div>
+          <div className='flex-1 overflow-hidden'>
+            <div className='truncate text-[12px] font-medium'>
+              {mockUser.name}
+            </div>
+          </div>
+          <ChevronDown className='size-3.5 text-muted-foreground' />
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/apps/web/app/sidebar-variations/_components/variation-racing.tsx
+++ b/apps/web/app/sidebar-variations/_components/variation-racing.tsx
@@ -1,0 +1,159 @@
+import { cn } from '@/lib/utils'
+import { mockGroup, mockUser, navSections } from './mock-data'
+
+const TEAM_COLORS = [
+  'rgb(var(--clr-team-ferrari))',
+  'rgb(var(--clr-team-mercedes))',
+  'rgb(var(--clr-team-mclaren))',
+  'rgb(var(--clr-team-red_bull))',
+  'rgb(var(--clr-team-aston_martin))',
+  'rgb(var(--clr-team-alpine))',
+  'rgb(var(--clr-team-williams))',
+  'rgb(var(--clr-team-haas))',
+]
+
+const carbonFibre = {
+  backgroundImage: `repeating-linear-gradient(45deg, rgba(255,255,255,0.025) 0 2px, transparent 2px 4px), repeating-linear-gradient(-45deg, rgba(255,255,255,0.02) 0 2px, transparent 2px 4px)`,
+}
+
+export function VariationRacing() {
+  let position = 0
+
+  return (
+    <aside
+      className='flex h-full w-64 flex-col bg-zinc-950 font-mono text-zinc-100'
+      style={carbonFibre}
+    >
+      <div className='border-b border-zinc-800'>
+        <div className='h-1 w-full bg-[#e10600]' />
+        <div className='flex items-center gap-2 px-3 py-3'>
+          <span className='relative flex size-2'>
+            <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500/75' />
+            <span className='relative inline-flex size-2 rounded-full bg-red-500' />
+          </span>
+          <div className='flex-1 truncate text-[11px] font-bold uppercase tracking-[0.2em]'>
+            {mockGroup.name}
+          </div>
+          <span className='rounded-sm bg-[#e10600] px-1.5 py-0.5 text-[9px] font-bold tracking-widest'>
+            LIVE
+          </span>
+        </div>
+      </div>
+
+      <nav className='flex-1 overflow-y-auto'>
+        {navSections.map((section, sectionIndex) => (
+          <div key={section.title} className='py-1'>
+            {sectionIndex > 0 && <CheckeredDivider />}
+            <div className='flex items-center gap-2 px-3 pt-2 pb-1.5'>
+              <div className='h-px flex-1 bg-zinc-800' />
+              <span className='text-[9px] font-bold uppercase tracking-[0.25em] text-zinc-500'>
+                {section.title}
+              </span>
+              <div className='h-px flex-1 bg-zinc-800' />
+            </div>
+            <ul>
+              {section.items.map((item) => {
+                position += 1
+                const teamColor = TEAM_COLORS[(position - 1) % TEAM_COLORS.length]
+                const pos = `P${String(position).padStart(2, '0')}`
+                return (
+                  <li key={item.title} className='relative'>
+                    {item.active && (
+                      <span className='absolute left-0 top-0 h-full w-[3px] bg-[#e10600]' />
+                    )}
+                    <a
+                      href={item.href}
+                      className={cn(
+                        'group flex items-center gap-2 px-3 py-2 transition-colors',
+                        'hover:bg-white/[0.04]',
+                        item.active && 'bg-red-600/15',
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          'font-mono text-[10px] font-bold tabular-nums',
+                          item.active ? 'text-[#e10600]' : 'text-zinc-500',
+                        )}
+                      >
+                        {pos}
+                      </span>
+                      <item.icon className='size-3.5 shrink-0 text-zinc-400 group-hover:text-zinc-100' />
+                      <span
+                        className={cn(
+                          'flex-1 truncate text-[11px] uppercase tracking-[0.12em]',
+                          item.active && 'font-bold',
+                        )}
+                      >
+                        {item.title}
+                      </span>
+                      <span
+                        className='h-4 w-[3px] shrink-0'
+                        style={{ backgroundColor: teamColor }}
+                        aria-hidden
+                      />
+                    </a>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        ))}
+      </nav>
+
+      <div className='border-t border-zinc-800 bg-black/40 p-3'>
+        <div className='text-[9px] font-bold uppercase tracking-[0.25em] text-zinc-500'>
+          Driver Card
+        </div>
+        <div className='mt-2 flex items-center gap-2'>
+          <div className='flex size-9 items-center justify-center rounded-sm border border-[#e10600]/60 bg-zinc-900 text-[10px] font-bold'>
+            {mockUser.initials}
+          </div>
+          <div className='flex-1 overflow-hidden leading-tight'>
+            <div className='truncate text-[11px] font-bold uppercase tracking-[0.12em]'>
+              {mockUser.name}
+            </div>
+            <div className='truncate text-[9px] uppercase tracking-[0.2em] text-zinc-500'>
+              No. 44 &middot; GBR
+            </div>
+          </div>
+        </div>
+        <TrackMap />
+      </div>
+    </aside>
+  )
+}
+
+function CheckeredDivider() {
+  return (
+    <div className='flex h-2 items-center gap-px overflow-hidden px-3'>
+      {Array.from({ length: 32 }).map((_, i) => (
+        <span
+          key={i}
+          className={cn(
+            'h-1 flex-1',
+            i % 2 === 0 ? 'bg-zinc-700' : 'bg-zinc-900',
+          )}
+        />
+      ))}
+    </div>
+  )
+}
+
+function TrackMap() {
+  return (
+    <svg
+      viewBox='0 0 200 40'
+      className='mt-2 h-6 w-full text-[#e10600]/70'
+      aria-hidden
+    >
+      <path
+        d='M5,25 C20,5 40,5 55,20 C70,35 90,35 110,25 C130,15 150,10 170,18 C185,24 195,22 195,15'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='1.5'
+        strokeLinecap='round'
+      />
+      <circle cx='5' cy='25' r='2' fill='currentColor' />
+    </svg>
+  )
+}

--- a/apps/web/app/sidebar-variations/_components/variation-rams.tsx
+++ b/apps/web/app/sidebar-variations/_components/variation-rams.tsx
@@ -1,0 +1,151 @@
+import { cn } from '@/lib/utils'
+import { mockUser, navSections } from './mock-data'
+
+const BRAUN_ORANGE = '#ff7a00'
+
+export function VariationRams() {
+  let runningIndex = 0
+
+  return (
+    <aside className='flex h-full w-64 flex-col border-r border-neutral-300 bg-[#f4f1ec] font-mono text-neutral-900 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100'>
+      <div className='flex items-center gap-3 border-b border-neutral-300 p-4 dark:border-neutral-800'>
+        <BraunDial />
+        <div className='leading-tight'>
+          <div className='text-[11px] font-bold uppercase tracking-[0.2em]'>
+            Gridtip
+          </div>
+          <div className='text-[9px] uppercase tracking-[0.15em] text-neutral-500'>
+            TS&middot;505
+          </div>
+        </div>
+      </div>
+
+      <nav className='flex-1 overflow-y-auto'>
+        {navSections.map((section, sectionIndex) => {
+          const start = runningIndex + 1
+          const end = runningIndex + section.items.length
+          const startStr = String(start).padStart(2, '0')
+          const endStr = String(end).padStart(2, '0')
+
+          return (
+            <div
+              key={section.title}
+              className={cn(
+                'border-b border-neutral-300 dark:border-neutral-800',
+                sectionIndex === 0 && 'border-t-0',
+              )}
+            >
+              <div className='px-4 pt-3 pb-1.5 text-[9px] uppercase tracking-[0.2em] text-neutral-500'>
+                {startStr}–{endStr}
+              </div>
+              <ul>
+                {section.items.map((item) => {
+                  runningIndex += 1
+                  const idx = String(runningIndex).padStart(2, '0')
+                  return (
+                    <li key={item.title}>
+                      <a
+                        href={item.href}
+                        className={cn(
+                          'relative flex items-center gap-3 px-4 py-2 text-[12px] uppercase tracking-[0.1em] transition-colors',
+                          'hover:bg-neutral-200/60 dark:hover:bg-neutral-800/60',
+                        )}
+                      >
+                        <span
+                          aria-hidden
+                          className={cn(
+                            'size-2 shrink-0',
+                            item.active ? 'block' : 'invisible',
+                          )}
+                          style={{ backgroundColor: BRAUN_ORANGE }}
+                        />
+                        <span className='w-6 text-neutral-500'>{idx}</span>
+                        <span className='text-neutral-400'>—</span>
+                        <span
+                          className={cn(
+                            'flex-1 truncate',
+                            item.active && 'font-bold',
+                          )}
+                        >
+                          {item.title}
+                        </span>
+                      </a>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          )
+        })}
+      </nav>
+
+      <div className='border-t-2 border-neutral-900 dark:border-neutral-100'>
+        <div className='flex items-center justify-between px-4 py-3'>
+          <div className='leading-tight'>
+            <div className='text-[9px] uppercase tracking-[0.2em] text-neutral-500'>
+              Operator
+            </div>
+            <div className='text-[11px] uppercase tracking-[0.15em]'>
+              {mockUser.name}
+            </div>
+          </div>
+          <div
+            className='size-2'
+            style={{ backgroundColor: BRAUN_ORANGE }}
+            aria-hidden
+          />
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+function BraunDial() {
+  return (
+    <svg
+      width='32'
+      height='32'
+      viewBox='0 0 32 32'
+      className='shrink-0'
+      aria-hidden
+    >
+      <circle
+        cx='16'
+        cy='16'
+        r='14'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='1'
+      />
+      <circle
+        cx='16'
+        cy='16'
+        r='9'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='1'
+      />
+      <line
+        x1='16'
+        y1='3'
+        x2='16'
+        y2='7'
+        stroke={BRAUN_ORANGE}
+        strokeWidth='2'
+      />
+      {[0, 45, 90, 135, 180, 225, 270, 315].map((deg) => (
+        <line
+          key={deg}
+          x1='16'
+          y1='1.5'
+          x2='16'
+          y2='3'
+          stroke='currentColor'
+          strokeWidth='0.6'
+          transform={`rotate(${deg} 16 16)`}
+          opacity={deg === 0 ? 0 : 0.5}
+        />
+      ))}
+    </svg>
+  )
+}

--- a/apps/web/app/sidebar-variations/_components/variation-similar.tsx
+++ b/apps/web/app/sidebar-variations/_components/variation-similar.tsx
@@ -1,0 +1,64 @@
+import { ChevronsUpDown, LogOut } from 'lucide-react'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+import { mockGroup, mockUser, navSections } from './mock-data'
+
+export function VariationSimilar() {
+  return (
+    <aside className='flex h-full w-64 flex-col bg-sidebar text-sidebar-foreground'>
+      <div className='flex items-center gap-2 p-2'>
+        <div className='flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground text-xs font-semibold'>
+          {mockGroup.initials}
+        </div>
+        <div className='flex-1 truncate text-sm font-medium'>
+          {mockGroup.name}
+        </div>
+        <ChevronsUpDown className='size-4 text-muted-foreground' />
+      </div>
+
+      <nav className='flex-1 overflow-y-auto px-2 py-2'>
+        {navSections.map((section, index) => (
+          <div key={section.title}>
+            {index > 0 && <Separator className='my-2' />}
+            <div className='px-2 pt-1 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+              {section.title}
+            </div>
+            <ul className='flex flex-col gap-0.5'>
+              {section.items.map((item) => (
+                <li key={item.title}>
+                  <a
+                    href={item.href}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+                      'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                      item.active &&
+                        'bg-sidebar-accent text-sidebar-accent-foreground font-medium',
+                    )}
+                  >
+                    <item.icon className='size-4 shrink-0' />
+                    <span className='truncate'>{item.title}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </nav>
+
+      <div className='border-t border-sidebar-border p-2'>
+        <div className='flex items-center gap-2 rounded-md p-2'>
+          <div className='flex size-8 items-center justify-center rounded-lg bg-sidebar-accent text-xs font-semibold'>
+            {mockUser.initials}
+          </div>
+          <div className='flex-1 overflow-hidden'>
+            <div className='truncate text-sm font-medium'>{mockUser.name}</div>
+            <div className='truncate text-xs text-muted-foreground'>
+              {mockUser.email}
+            </div>
+          </div>
+          <LogOut className='size-4 text-muted-foreground' />
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/apps/web/app/sidebar-variations/page.tsx
+++ b/apps/web/app/sidebar-variations/page.tsx
@@ -1,0 +1,74 @@
+import { VariationLinear } from './_components/variation-linear'
+import { VariationRacing } from './_components/variation-racing'
+import { VariationRams } from './_components/variation-rams'
+import { VariationSimilar } from './_components/variation-similar'
+
+const variations = [
+  {
+    id: 'similar',
+    title: 'Similar',
+    description:
+      'Layout alike to the current sidebar, but with per-link icons and section separators replacing the toggleable headers.',
+    component: <VariationSimilar />,
+  },
+  {
+    id: 'linear',
+    title: 'Industry best practices',
+    description:
+      'Density, restraint, and refined micro-detail in the spirit of Linear and Emil Kowalski — flat list, ⌘K hint, keyboard shortcuts on hover.',
+    component: <VariationLinear />,
+  },
+  {
+    id: 'rams',
+    title: 'The Rams',
+    description:
+      'Dieter Rams meets Braun TS-505. Numbered grid, mono type, single accent of Braun orange, control-panel discipline.',
+    component: <VariationRams />,
+  },
+  {
+    id: 'racing',
+    title: 'Racing',
+    description:
+      'F1 timing-tower aesthetic. Position prefixes, team-colour stripes, checkered dividers, Driver Card footer.',
+    component: <VariationRacing />,
+  },
+]
+
+export default function SidebarVariationsPage() {
+  return (
+    <main className='min-h-screen bg-background px-6 py-10'>
+      <div className='mx-auto max-w-[1600px]'>
+        <header className='mb-10'>
+          <h1 className='text-3xl font-semibold tracking-tight'>
+            Sidebar variations
+          </h1>
+          <p className='mt-2 max-w-2xl text-muted-foreground'>
+            Four design directions for the GridTip sidebar, rendered side by
+            side at the live sidebar's 16rem width. Links are placeholders.
+          </p>
+        </header>
+
+        <div className='grid grid-cols-1 gap-6 lg:grid-cols-2 2xl:grid-cols-4'>
+          {variations.map((variation) => (
+            <section
+              key={variation.id}
+              className='flex flex-col rounded-lg border bg-card text-card-foreground shadow-sm'
+            >
+              <div className='border-b p-4'>
+                <h2 className='text-lg font-medium'>{variation.title}</h2>
+                <p className='mt-1 text-sm text-muted-foreground'>
+                  {variation.description}
+                </p>
+              </div>
+              <div className='flex justify-center bg-muted/30 p-4'>
+                <div className='h-[640px] overflow-hidden rounded-md border shadow-sm'>
+                  {variation.component}
+                </div>
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "gridtip-mono",


### PR DESCRIPTION
Four POC sidebar designs rendered side-by-side at /sidebar-variations:
Similar (icons + separators), Linear/Emil-inspired (density + ⌘K hint),
Dieter Rams (numbered grid, Braun orange accent), and Racing (F1 timing
tower). Mocked data, placeholder hrefs — design exploration only.

https://claude.ai/code/session_01Gb3iZEsYTNsNZSEPTFjLD3