### PR TITLE
Refactor icon rendering to use Icon wrapper component

### DIFF
--- a/apps/mobile/src/app/(app)/home/_components/position-modal.tsx
+++ b/apps/mobile/src/app/(app)/home/_components/position-modal.tsx
@@ -35,10 +35,9 @@ export default function PositionModal({
       navigationBarTranslucent={true}
       statusBarTranslucent={true}
       presentationStyle="formSheet"
-      className="bg-background"
     >
       <SafeAreaProvider>
-        <SafeAreaView>
+        <SafeAreaView className="flex-1 bg-background">
           <ModalHeader position={position} dismiss={dismiss} />
           <ModalBody
             position={position}

--- a/apps/mobile/src/app/(app)/links/index.tsx
+++ b/apps/mobile/src/app/(app)/links/index.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router'
 import { Pressable, ScrollView, View } from 'react-native'
 import { ChevronRight } from 'lucide-react-native'
+import { Icon } from '@/components/ui/icon'
 import { Text } from '@/components/ui/text'
 import { linkItems, openLink } from '../../../lib/link-items'
 
@@ -11,7 +12,6 @@ export default function LinksScreen() {
       <ScrollView className="flex-1 bg-background">
         <View className="mt-4 mx-4 rounded-xl bg-card border border-border overflow-hidden">
           {linkItems.map((item, index) => {
-            const Icon = item.icon
             const isLast = index === linkItems.length - 1
             return (
               <Pressable
@@ -25,7 +25,7 @@ export default function LinksScreen() {
                   }`}
                 >
                   <View className="h-9 w-9 items-center justify-center rounded-lg bg-muted">
-                    <Icon size={20} className="text-foreground" />
+                    <Icon as={item.icon} size={20} className="text-muted-foreground" />
                   </View>
                   <View className="flex-1">
                     <Text className="text-base font-medium">{item.title}</Text>
@@ -33,7 +33,7 @@ export default function LinksScreen() {
                       {item.description}
                     </Text>
                   </View>
-                  <ChevronRight size={18} className="text-muted-foreground" />
+                  <Icon as={ChevronRight} size={18} className="text-muted-foreground" />
                 </View>
               </Pressable>
             )


### PR DESCRIPTION
## Summary
This PR refactors icon rendering across the mobile app to use a centralized `Icon` wrapper component instead of directly rendering icon components. This improves consistency and maintainability of icon usage throughout the codebase.

## Key Changes
- **Links screen**: Replaced direct icon component rendering with the `Icon` wrapper component
  - Changed from destructuring `item.icon` and rendering it directly to using `<Icon as={item.icon} />`
  - Updated the chevron icon to also use the `Icon` wrapper for consistency
  - Adjusted color from `text-foreground` to `text-muted-foreground` for the item icon

- **Position modal**: Fixed SafeAreaView styling
  - Moved `bg-background` class from Modal to SafeAreaView for proper background application
  - Added `flex-1` to SafeAreaView to ensure proper layout

## Implementation Details
The refactoring uses the `as` prop pattern on the `Icon` component to accept different icon components, providing a single point of control for icon rendering behavior and styling across the application.

https://claude.ai/code/session_012kQDfmKuDAfXsKg8WiAFSq