### PR TITLE
retry transient Turso connection errors in scripts and update endpoints

### DIFF
--- a/apps/web/__tests__/with-retry.test.ts
+++ b/apps/web/__tests__/with-retry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import { withRetry } from '@/lib/utils/with-retry'
+
+function transientError() {
+  return Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' })
+}
+
+describe('withRetry', () => {
+  it('resolves immediately without retrying when fn succeeds', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+
+    await expect(withRetry(fn, { baseDelayMs: 0 })).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transient connection error and eventually succeeds', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(transientError())
+      .mockRejectedValueOnce(transientError())
+      .mockResolvedValue('ok')
+
+    await expect(withRetry(fn, { baseDelayMs: 0 })).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries when the transient error is nested in the cause chain', async () => {
+    const wrapped = new Error('Failed query: select ...', {
+      cause: transientError(),
+    })
+    const fn = vi.fn().mockRejectedValueOnce(wrapped).mockResolvedValue('ok')
+
+    await expect(withRetry(fn, { baseDelayMs: 0 })).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('detects a transient error by message when no code is present', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error('The socket connection was closed unexpectedly'),
+      )
+      .mockResolvedValue('ok')
+
+    await expect(withRetry(fn, { baseDelayMs: 0 })).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry a non-transient error', async () => {
+    const error = new Error('bad query')
+    const fn = vi.fn().mockRejectedValue(error)
+
+    await expect(withRetry(fn, { baseDelayMs: 0 })).rejects.toBe(error)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws the original error after exhausting retries', async () => {
+    const error = transientError()
+    const fn = vi.fn().mockRejectedValue(error)
+
+    await expect(
+      withRetry(fn, { retries: 2, baseDelayMs: 0 }),
+    ).rejects.toBe(error)
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+})

--- a/apps/web/app/api/constructors/update/route.ts
+++ b/apps/web/app/api/constructors/update/route.ts
@@ -11,6 +11,7 @@ import { ConstructorsResponse } from '@/types/ergast'
 import { db } from '@/db'
 import { constructorsTable } from '@/db/schema/schema'
 import { sql } from 'drizzle-orm'
+import { withRetry } from '@/lib/utils/with-retry'
 
 export const GET = async (_request: NextRequest) => {
   const validationResponse = await validateToken()
@@ -46,13 +47,17 @@ export const GET = async (_request: NextRequest) => {
   ) {
     const getStoredConstructors = unstable_cache(
       async () =>
-        await db.query.constructorsTable.findMany({
-          columns: {
-            id: true,
-            name: true,
-            nationality: true,
-          },
-        }),
+        await withRetry(
+          () =>
+            db.query.constructorsTable.findMany({
+              columns: {
+                id: true,
+                name: true,
+                nationality: true,
+              },
+            }),
+          { label: 'load stored constructors' },
+        ),
       [],
       {
         tags: [CacheTag.Constructors],
@@ -107,33 +112,35 @@ export const GET = async (_request: NextRequest) => {
   }
 
   async function setConstructorsInDatabase(constructors: JolpicaConstructors) {
-    const returning = await db
-      .insert(constructorsTable)
-      .values(
-        constructors.map((constructor) => {
-          if (!constructor.constructorId) {
-            throw new Error('No constructorId included')
-          }
-          return {
-            id: constructor.constructorId,
-            name: constructor.name,
-            nationality: constructor.nationality ?? '',
-            lastUpdated: new Date(),
-          }
-        }),
-      )
-      .onConflictDoUpdate({
-        target: constructorsTable.id,
-        set: {
-          name: sql`excluded.name`,
-          nationality: sql`excluded.nationality`,
-          lastUpdated: sql`excluded.last_updated`,
-        },
-      })
-
-      .returning({
-        id: constructorsTable.id,
-      })
+    const values = constructors.map((constructor) => {
+      if (!constructor.constructorId) {
+        throw new Error('No constructorId included')
+      }
+      return {
+        id: constructor.constructorId,
+        name: constructor.name,
+        nationality: constructor.nationality ?? '',
+        lastUpdated: new Date(),
+      }
+    })
+    const returning = await withRetry(
+      () =>
+        db
+          .insert(constructorsTable)
+          .values(values)
+          .onConflictDoUpdate({
+            target: constructorsTable.id,
+            set: {
+              name: sql`excluded.name`,
+              nationality: sql`excluded.nationality`,
+              lastUpdated: sql`excluded.last_updated`,
+            },
+          })
+          .returning({
+            id: constructorsTable.id,
+          }),
+      { label: 'upsert constructors' },
+    )
     return returning
   }
 }

--- a/apps/web/app/api/drivers/update/route.ts
+++ b/apps/web/app/api/drivers/update/route.ts
@@ -8,6 +8,7 @@ import { driversTable } from '@/db/schema/schema'
 import { sql } from 'drizzle-orm'
 import { Database } from '@/db/types'
 import * as Sentry from '@sentry/nextjs'
+import { withRetry } from '@/lib/utils/with-retry'
 
 export const GET = async (_request: NextRequest) => {
   const validationResponse = await validateToken()
@@ -153,11 +154,15 @@ export const GET = async (_request: NextRequest) => {
   async function getJolpicaDrivers() {
     const getConstructorsIds = unstable_cache(
       async () =>
-        await db.query.constructorsTable.findMany({
-          columns: {
-            id: true,
-          },
-        }),
+        await withRetry(
+          () =>
+            db.query.constructorsTable.findMany({
+              columns: {
+                id: true,
+              },
+            }),
+          { label: 'load constructor ids' },
+        ),
       [],
       {
         tags: [CacheTag.Constructors],
@@ -200,24 +205,28 @@ export const GET = async (_request: NextRequest) => {
   }
 
   async function setDriversInDatabase(drivers: JolpicaDrivers) {
-    const returning = await db
-      .insert(driversTable)
-      .values(drivers)
-      .onConflictDoUpdate({
-        target: driversTable.id,
-        set: {
-          permanentNumber: sql`excluded.permanent_number`,
-          fullName: sql`excluded.full_name`,
-          givenName: sql`excluded.given_name`,
-          familyName: sql`excluded.family_name`,
-          nationality: sql`excluded.nationality`,
-          constructorId: sql`excluded.constructor_id`,
-          lastUpdated: sql`excluded.last_updated`,
-        },
-      })
-      .returning({
-        id: driversTable.id,
-      })
+    const returning = await withRetry(
+      () =>
+        db
+          .insert(driversTable)
+          .values(drivers)
+          .onConflictDoUpdate({
+            target: driversTable.id,
+            set: {
+              permanentNumber: sql`excluded.permanent_number`,
+              fullName: sql`excluded.full_name`,
+              givenName: sql`excluded.given_name`,
+              familyName: sql`excluded.family_name`,
+              nationality: sql`excluded.nationality`,
+              constructorId: sql`excluded.constructor_id`,
+              lastUpdated: sql`excluded.last_updated`,
+            },
+          })
+          .returning({
+            id: driversTable.id,
+          }),
+      { label: 'upsert drivers' },
+    )
     return returning
   }
 }

--- a/apps/web/app/api/races/update/route.ts
+++ b/apps/web/app/api/races/update/route.ts
@@ -13,6 +13,7 @@ import { racesTable } from '@/db/schema/schema'
 import { sql } from 'drizzle-orm'
 import { Database } from '@/db/types'
 import * as Sentry from '@sentry/nextjs'
+import { withRetry } from '@/lib/utils/with-retry'
 
 export const GET = async (_request: NextRequest) => {
   const validationResponse = await validateToken()
@@ -57,7 +58,10 @@ export const GET = async (_request: NextRequest) => {
 
   async function getIsThereDifferenceInRaces(newItems: JolpicaRaces) {
     const getStoredRaces = unstable_cache(
-      async () => await db.query.racesTable.findMany(),
+      async () =>
+        await withRetry(() => db.query.racesTable.findMany(), {
+          label: 'load stored races',
+        }),
       [],
       {
         tags: [CacheTag.Races],
@@ -147,27 +151,31 @@ export const GET = async (_request: NextRequest) => {
   }
 
   async function setRacesInDatabase(races: JolpicaRaces) {
-    const returning = await db
-      .insert(racesTable)
-      .values(races)
-      .onConflictDoUpdate({
-        target: racesTable.id,
-        set: {
-          country: sql`excluded.country`,
-          round: sql`excluded.round`,
-          circuitName: sql`excluded.circuit_name`,
-          raceName: sql`excluded.race_name`,
-          grandPrixDate: sql`excluded.grand_prix_date`,
-          qualifyingDate: sql`excluded.qualifying_date`,
-          sprintDate: sql`excluded.sprint_date`,
-          sprintQualifyingDate: sql`excluded.sprint_qualifying_date`,
-          locality: sql`excluded.locality`,
-          lastUpdated: sql`excluded.last_updated`,
-        },
-      })
-      .returning({
-        id: racesTable.id,
-      })
+    const returning = await withRetry(
+      () =>
+        db
+          .insert(racesTable)
+          .values(races)
+          .onConflictDoUpdate({
+            target: racesTable.id,
+            set: {
+              country: sql`excluded.country`,
+              round: sql`excluded.round`,
+              circuitName: sql`excluded.circuit_name`,
+              raceName: sql`excluded.race_name`,
+              grandPrixDate: sql`excluded.grand_prix_date`,
+              qualifyingDate: sql`excluded.qualifying_date`,
+              sprintDate: sql`excluded.sprint_date`,
+              sprintQualifyingDate: sql`excluded.sprint_qualifying_date`,
+              locality: sql`excluded.locality`,
+              lastUpdated: sql`excluded.last_updated`,
+            },
+          })
+          .returning({
+            id: racesTable.id,
+          }),
+      { label: 'upsert races' },
+    )
     return returning
   }
 }

--- a/apps/web/app/api/results/update/route.ts
+++ b/apps/web/app/api/results/update/route.ts
@@ -13,6 +13,7 @@ import { db } from '@/db'
 import { resultsTable } from '@/db/schema/schema'
 import { Database } from '@/db/types'
 import * as Sentry from '@sentry/nextjs'
+import { withRetry } from '@/lib/utils/with-retry'
 
 export const GET = async (_request: NextRequest) => {
   const validationResponse = await validateToken()
@@ -57,7 +58,10 @@ export const GET = async (_request: NextRequest) => {
 
   async function getIsThereDifferenceInResults(newItems: JolpicaResults) {
     const getStoredResults = unstable_cache(
-      async () => await db.query.resultsTable.findMany(),
+      async () =>
+        await withRetry(() => db.query.resultsTable.findMany(), {
+          label: 'load stored results',
+        }),
       [],
       {
         tags: [CacheTag.Results],
@@ -255,10 +259,19 @@ export const GET = async (_request: NextRequest) => {
   }
 
   async function setResultsInDatabase(results: JolpicaResults) {
-    await db.delete(resultsTable) // we're being a bit lazy here and just dropping the whole table instead of checking which results actually changed. something to optimise later
-    const returning = await db.insert(resultsTable).values(results).returning({
-      id: resultsTable.id,
-    })
+    // we're being a bit lazy here and just dropping the whole table instead of
+    // checking which results actually changed. something to optimise later.
+    // delete + insert are retried together: the delete is idempotent, so a retry
+    // of the pair after a transient failure is safe.
+    const returning = await withRetry(
+      async () => {
+        await db.delete(resultsTable)
+        return db.insert(resultsTable).values(results).returning({
+          id: resultsTable.id,
+        })
+      },
+      { label: 'replace results' },
+    )
     return returning
   }
 }

--- a/apps/web/lib/utils/with-retry.ts
+++ b/apps/web/lib/utils/with-retry.ts
@@ -1,0 +1,71 @@
+type WithRetryOptions = {
+  retries?: number
+  baseDelayMs?: number
+  label?: string
+}
+
+const RETRYABLE_CODES = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+]
+
+const RETRYABLE_MESSAGES = [
+  'socket connection was closed',
+  'fetch failed',
+  'connect timeout',
+]
+
+function isTransientConnectionError(error: unknown): boolean {
+  let current: unknown = error
+  const seen = new Set<unknown>()
+
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current)
+    const err = current as { code?: unknown; message?: unknown; cause?: unknown }
+
+    if (typeof err.code === 'string' && RETRYABLE_CODES.includes(err.code)) {
+      return true
+    }
+    if (typeof err.message === 'string') {
+      const message = err.message.toLowerCase()
+      if (RETRYABLE_MESSAGES.some((pattern) => message.includes(pattern))) {
+        return true
+      }
+    }
+
+    current = err.cause
+  }
+
+  return false
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Runs `fn`, retrying on transient Turso/libsql connection errors (ECONNRESET,
+ * dropped sockets, etc.) with exponential backoff. Only use for operations that
+ * are safe to retry (reads, or idempotent writes).
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: WithRetryOptions = {},
+): Promise<T> {
+  const { retries = 3, baseDelayMs = 500, label = 'operation' } = options
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      if (attempt >= retries || !isTransientConnectionError(error)) {
+        throw error
+      }
+      const delay = baseDelayMs * 2 ** attempt
+      console.warn(
+        `${label}: transient connection error, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`,
+      )
+      await wait(delay)
+    }
+  }
+}

--- a/apps/web/scripts/send-race-reminders.ts
+++ b/apps/web/scripts/send-race-reminders.ts
@@ -15,6 +15,7 @@ import {
   type SchedulerUser,
 } from '@/lib/notifications/compute-notifications'
 import { sendNotifications } from '@/lib/notifications/send'
+import { withRetry } from '@/lib/utils/with-retry'
 import { addHours, subHours } from 'date-fns'
 import { and, eq, gte, inArray } from 'drizzle-orm'
 
@@ -31,52 +32,56 @@ async function main() {
     rawRaces,
     rawPredictions,
     rawSent,
-  ] = await Promise.all([
-    db.query.user.findMany({
-      where: eq(user.enableNotifications, true),
-      columns: { id: true, enableNotifications: true },
-    }),
-    db.query.userPushTokensTable.findMany({
-      columns: { userId: true, token: true },
-    }),
-    db.query.groupMembersTable.findMany({
-      columns: { userId: true, groupId: true },
-      with: {
-        group: { columns: { cutoffInMinutes: true } },
-      },
-    }),
-    db.query.racesTable.findMany({
-      columns: {
-        id: true,
-        qualifyingDate: true,
-        sprintQualifyingDate: true,
-      },
-      where: and(
-        gte(racesTable.qualifyingDate, horizonStart),
-        // grandPrixDate guard not needed; we filter on qualifying horizon
-      ),
-    }),
-    db
-      .select({
-        userId: groupMembersTable.userId,
-        raceId: predictionsTable.raceId,
-      })
-      .from(predictionsTable)
-      .innerJoin(
-        groupMembersTable,
-        eq(predictionsTable.memberId, groupMembersTable.id),
-      )
-      .where(eq(predictionsTable.isForChampionship, false)),
-    db.query.raceNotificationsTable.findMany({
-      columns: {
-        userId: true,
-        raceId: true,
-        tipType: true,
-        reminderType: true,
-      },
-      where: gte(raceNotificationsTable.sentAt, subHours(now, 48)),
-    }),
-  ])
+  ] = await withRetry(
+    () =>
+      Promise.all([
+        db.query.user.findMany({
+          where: eq(user.enableNotifications, true),
+          columns: { id: true, enableNotifications: true },
+        }),
+        db.query.userPushTokensTable.findMany({
+          columns: { userId: true, token: true },
+        }),
+        db.query.groupMembersTable.findMany({
+          columns: { userId: true, groupId: true },
+          with: {
+            group: { columns: { cutoffInMinutes: true } },
+          },
+        }),
+        db.query.racesTable.findMany({
+          columns: {
+            id: true,
+            qualifyingDate: true,
+            sprintQualifyingDate: true,
+          },
+          where: and(
+            gte(racesTable.qualifyingDate, horizonStart),
+            // grandPrixDate guard not needed; we filter on qualifying horizon
+          ),
+        }),
+        db
+          .select({
+            userId: groupMembersTable.userId,
+            raceId: predictionsTable.raceId,
+          })
+          .from(predictionsTable)
+          .innerJoin(
+            groupMembersTable,
+            eq(predictionsTable.memberId, groupMembersTable.id),
+          )
+          .where(eq(predictionsTable.isForChampionship, false)),
+        db.query.raceNotificationsTable.findMany({
+          columns: {
+            userId: true,
+            raceId: true,
+            tipType: true,
+            reminderType: true,
+          },
+          where: gte(raceNotificationsTable.sentAt, subHours(now, 48)),
+        }),
+      ]),
+    { label: 'load reminder data' },
+  )
 
   const tokensByUser = new Map<string, string[]>()
   for (const t of rawTokens) {
@@ -128,23 +133,27 @@ async function main() {
   // Claim ledger rows up front so an overlapping cron run can't double-send.
   // Failed sends are accepted as lost reminders; the next cutoff window will
   // still fire if applicable.
-  const claimed = await db
-    .insert(raceNotificationsTable)
-    .values(
-      notifications.map((n) => ({
-        userId: n.userId,
-        raceId: n.raceId,
-        tipType: n.tipType,
-        reminderType: n.reminderType,
-      })),
-    )
-    .onConflictDoNothing()
-    .returning({
-      userId: raceNotificationsTable.userId,
-      raceId: raceNotificationsTable.raceId,
-      tipType: raceNotificationsTable.tipType,
-      reminderType: raceNotificationsTable.reminderType,
-    })
+  const claimed = await withRetry(
+    () =>
+      db
+        .insert(raceNotificationsTable)
+        .values(
+          notifications.map((n) => ({
+            userId: n.userId,
+            raceId: n.raceId,
+            tipType: n.tipType,
+            reminderType: n.reminderType,
+          })),
+        )
+        .onConflictDoNothing()
+        .returning({
+          userId: raceNotificationsTable.userId,
+          raceId: raceNotificationsTable.raceId,
+          tipType: raceNotificationsTable.tipType,
+          reminderType: raceNotificationsTable.reminderType,
+        }),
+    { label: 'claim notification rows' },
+  )
 
   const claimedKey = new Set(
     claimed.map(
@@ -165,9 +174,13 @@ async function main() {
   const { results, invalidTokens } = await sendNotifications(toSend)
 
   if (invalidTokens.length > 0) {
-    await db
-      .delete(userPushTokensTable)
-      .where(inArray(userPushTokensTable.token, invalidTokens))
+    await withRetry(
+      () =>
+        db
+          .delete(userPushTokensTable)
+          .where(inArray(userPushTokensTable.token, invalidTokens)),
+      { label: 'prune push tokens' },
+    )
     console.log(`pruned ${invalidTokens.length} unregistered push token(s)`)
   }
 


### PR DESCRIPTION
The send-race-reminders job failed on a transient ECONNRESET from Turso
with no retry anywhere. Add a withRetry helper with exponential backoff
that retries idempotent DB operations on transient connection errors, and
apply it to the reminders script and the four update API route handlers.

https://claude.ai/code/session_01H6sCCkdXZsC2soXQZJtQzb